### PR TITLE
fix: fix for e2e testsuite setup

### DIFF
--- a/suite/scripts/panacea-init-all.sh
+++ b/suite/scripts/panacea-init-all.sh
@@ -49,8 +49,7 @@ for (( i=0; i < $NUM_VALIDATORS; i++ )); do
 done
 
 # add genesis oracle
-MONIKER="$CHAIN_ID-val-0"
-$BIN add-genesis-oracle --oracle-account $(panacead keys show val -a --home $CHAIN_DIR/$MONIKER) --home $CHAIN_DIR/$FIRST_MONIKER
+$BIN add-genesis-oracle --oracle-account $(panacead keys show val -a --home $CHAIN_DIR/"$CHAIN_ID-val-0") --home $CHAIN_DIR/$FIRST_MONIKER
 
 for (( i=0; i < $NUM_VALIDATORS; i++ )); do
     MONIKER="$CHAIN_ID-val-$i"

--- a/suite/scripts/panacea-init-all.sh
+++ b/suite/scripts/panacea-init-all.sh
@@ -48,6 +48,10 @@ for (( i=0; i < $NUM_VALIDATORS; i++ )); do
     $BIN add-genesis-account $(panacead keys show val -a --home $CHAIN_DIR/$MONIKER) $GEN_ACC_BALANCE --home $CHAIN_DIR/$FIRST_MONIKER
 done
 
+# add genesis oracle
+MONIKER="$CHAIN_ID-val-0"
+$BIN add-genesis-oracle --oracle-account $(panacead keys show val -a --home $CHAIN_DIR/$MONIKER) --home $CHAIN_DIR/$FIRST_MONIKER
+
 for (( i=0; i < $NUM_VALIDATORS; i++ )); do
     MONIKER="$CHAIN_ID-val-$i"
 

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -17,8 +17,8 @@ type TestSuite struct {
 
 	opts TestSuiteOptions
 
-	mnemonic string
-	Chain    *Chain
+	mnemonic    string
+	Chain       *Chain
 	oracleGroup *oracleGroup
 
 	dkrPool *dockertest.Pool
@@ -77,7 +77,7 @@ func (s *TestSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.T().Logf("submitting a gov proposal for oracles...")
-	s.Chain.validators[0].submitGovParamChangeProposal(proposalHostPath)
+	err = s.Chain.validators[0].submitGovParamChangeProposal(proposalHostPath)
 	s.Require().NoError(err)
 
 	s.T().Logf("voting on the gov proposal...")

--- a/suite/util.go
+++ b/suite/util.go
@@ -73,7 +73,7 @@ func queryLatestBlock(endpoint string) (string, int64, error) {
 	return hash, height, nil
 }
 
-func queryTxRespCode(endpoint, txHash string) (int, error) {
+func queryTxRespCode(endpoint, txHash string) (float64, error) {
 	resp, err := http.Get(fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", endpoint, txHash))
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute HTTP request: %w", err)
@@ -90,7 +90,7 @@ func queryTxRespCode(endpoint, txHash string) (int, error) {
 	}
 
 	txResp := result["tx_response"].(map[string]interface{})
-	return txResp["code"].(int), nil
+	return txResp["code"].(float64), nil
 }
 
 func queryGovProposal(endpoint string, proposalID int) (*govtypes.QueryProposalResponse, error) {


### PR DESCRIPTION
I fixed minor things for setting up e2e testsuite.
- add genesis oracle in panacea chain initialization
- change type of tx response code (because its type is `float64`)